### PR TITLE
Fixed typos in Requests List

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Then you can make Xbox API requests with this object. For example, get API key o
 profile_info = api.get_profile()  # returns dictionary of objects
 print(profile_info)
 ```
+
 >{
 >  u'locale': u'en-US',  # Unicode strings
 >  u'midasConsole': None,
@@ -37,10 +38,10 @@ print(profile_info)
 #### `get_xuid()` - user personal xbox uid
 #### `get_messages()` - user account messages with full preview
 #### `get_conversations()` - user conversations with full preview of the last message sent/recieved
-#### `get_xuid_by_gametag(gametag)` - user XUID for a specified Gamertag
-#### `get_gametag_by_xuid(xuid)` - Gamertag for a specified XUID
+#### `get_xuid_by_gamertag(gamertag)` - user XUID for a specified Gamertag
+#### `get_gamertag_by_xuid(xuid)` - Gamertag for a specified XUID
 #### `get_user_profile(xuid)` - Profile for a specified XUID
-#### `get_user_gamecard(xuid)` - Gamercard information for a specified XUID
+#### `get_user_gamercard(xuid)` - Gamercard information for a specified XUID
 #### `get_user_presence(xuid)` - current presence information for a specified XUID
 #### `get_user_activity(xuid)` - current activity information for a specified XUID
 #### `get_user_activity_recent(xuid)` - recent activity information for a specified XUID


### PR DESCRIPTION
README.md had 3 typos in the requests list. 
(Every instance of "Gamer" was missing it's "r")
I thought it would save some confusion for some who try to use it and just think it doesn't work when it is actually missing a letter